### PR TITLE
o Use tablesorter shortDate sorter to sort datetime columns.

### DIFF
--- a/debomatic-webui/public/javascripts/page_history.js
+++ b/debomatic-webui/public/javascripts/page_history.js
@@ -83,17 +83,6 @@ function Page_History() {
             sortAsc: 'glyphicon glyphicon-chevron-up',
             sortDesc: 'glyphicon glyphicon-chevron-down',
         });
-        $.tablesorter.addParser({
-            id: "datetime",
-            is: function (s) {
-                return false;
-            },
-            format: function (s, table) {
-                s = s.replace(/(\d{1,2})[\/\-](\d{1,2})[\/\-](\d{4})(.*)/, "$3/$2/$1$4");
-                return $.tablesorter.formatFloat(new Date(s).getTime());
-            },
-            type: "numeric"
-        });
 
         // call the tablesorter plugin and apply the uitheme widget
         $("table").tablesorter({
@@ -109,10 +98,10 @@ function Page_History() {
             },
             headers: {
                 2: {
-                    sorter: 'datetime'
+                    sorter: 'shortDate'
                 },
                 3: {
-                    sorter: 'datetime'
+                    sorter: 'shortDate'
                 }
             }
         });


### PR DESCRIPTION
November builds were reported as though they occurred before December builds, apparently due to some sorting problem. My brain shut off when it saw the regular expression so I'm not exactly sure the bug.

This patch causes my builds to be ordered correctly.
